### PR TITLE
Make the randomized antisnipe period in minutes configurable.

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ module.exports = {
   admins: parseAdmins(process.env.ADMINS) || ['012345'],
   sbPrefix: '/sb',
   senderEmail: process.env.SENDER_EMAIL || 'admin@bitcointalk.org',
+  antiSnipeMinutes: process.env.ANTISNIPE_MINUTES || 30,
   redis: {
     host: process.env.REDIS_HOST || '127.0.0.1',
     port: process.env.REDIS_PORT || 6379

--- a/db.js
+++ b/db.js
@@ -14,7 +14,7 @@ var db = {
 
     // random true ending time of auction within 30 minutes of end
     var end = Number(body.end);
-    var timeDifference = (1000 * 60 * 30);
+    var timeDifference = (1000 * 60 * config.antiSnipeMinutes);
     var trueEnd = Math.floor(Math.random() * (timeDifference+1));
     trueEnd = new Date(end).getTime() + trueEnd;
 

--- a/seed.js
+++ b/seed.js
@@ -37,7 +37,7 @@ var seed = function() {
   var start = new Date();
   var end = new Date(start);
   end.setHours(end.getHours() + 4);
-  var timeDifference = (1000 * 60 * 30);
+  var timeDifference = (1000 * 60 * config.antiSnipeMinutes);
   var trueEnd = Math.floor(Math.random() * (timeDifference+1));
   trueEnd = end.getTime() + trueEnd;
 


### PR DESCRIPTION
Set to 0 if you want the auction end time to be exact, which can be
helpful in testing.
